### PR TITLE
Add resolver support to the non-ssl vhost

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -5,6 +5,9 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
 <% end %>
   server_name           <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
+<% if defined? @resolver -%>
+  resolver              <%= @resolver %>;
+<% end -%>
 <% if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";
 <% end -%>


### PR DESCRIPTION
I would have added tests but I can't get 'bundle exec rake spec' to run :-( http://pastebin.com/cnye4a40
